### PR TITLE
Add flow-typed defs for react-redux and react-native

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -68,9 +68,8 @@ export default class Main extends Component {
 						<DataSearch
 							componentId="DataSeachComponent"
 							dataField="name"
-							onQueryChange={(prev, next) => {
-								console.log(prev, next);
-							}}
+							defaultSelected="Nissan"
+							onValueChange={(val) => console.log("DataSearch onValueChange", val)}
 							react={{
 								and: "TextFieldComponent"
 							}}

--- a/flow-typed/react-native.js
+++ b/flow-typed/react-native.js
@@ -1,0 +1,3 @@
+declare module 'react-native' {
+	declare module.exports: any;
+}

--- a/flow-typed/react-redux.js
+++ b/flow-typed/react-redux.js
@@ -1,0 +1,3 @@
+declare module 'react-redux' {
+	declare module.exports: any;
+}

--- a/src/sensors/DataSearch.js
+++ b/src/sensors/DataSearch.js
@@ -41,6 +41,9 @@ class DataSearch extends Component {
 			}
 			this.props.updateQuery(component, query(value), callback);
 		}, 300);
+		if (this.props.defaultSelected) {
+			this.setValue(this.props.defaultSelected);
+		}
 	}
 
 	componentWillReceiveProps(nextProps) {
@@ -53,6 +56,9 @@ class DataSearch extends Component {
 			this.setState({
 				suggestions: nextProps.suggestions
 			});
+		}
+		if (this.props.defaultSelected !== nextProps.defaultSelected) {
+			this.setValue(nextProps.defaultSelected);
 		}
 	}
 
@@ -71,7 +77,7 @@ class DataSearch extends Component {
 		}
 	}
 
-	defaultQuery(value) {
+	defaultQuery = (value) => {
 		let finalQuery = null,
 			fields;
 		if (value) {

--- a/src/sensors/DataSearch.js
+++ b/src/sensors/DataSearch.js
@@ -33,16 +33,8 @@ class DataSearch extends Component {
 		this.props.addComponent(this.internalComponent);
 		this.setReact(this.props);
 
-		this.updateQuery = debounce((component, value) => {
-			const query = this.props.customQuery || this.defaultQuery;
-			let callback = null;
-			if (component === this.props.componentId && this.props.onQueryChange) {
-				callback = this.props.onQueryChange;
-			}
-			this.props.updateQuery(component, query(value), callback);
-		}, 300);
 		if (this.props.defaultSelected) {
-			this.setValue(this.props.defaultSelected);
+			this.setDefaultValue(this.props.defaultSelected);
 		}
 	}
 
@@ -58,7 +50,7 @@ class DataSearch extends Component {
 			});
 		}
 		if (this.props.defaultSelected !== nextProps.defaultSelected) {
-			this.setValue(nextProps.defaultSelected);
+			this.setDefaultValue(nextProps.defaultSelected);
 		}
 	}
 
@@ -152,22 +144,66 @@ class DataSearch extends Component {
 	}
 
 	setValue = (value) => {
-		this.setState({
-			currentValue: value
-		});
-		if (this.props.autoSuggest) {
-			this.updateQuery(this.internalComponent, value);
+		const performUpdate = () => {
+			if (this.props.onValueChange) {
+				this.props.onValueChange(value);
+			}
+			this.setState({
+				currentValue: value
+			});
+			// debounce for handling text while typing
+			debounce(() => {
+				if (this.props.autoSuggest) {
+					this.updateQuery(this.internalComponent, value);
+				} else {
+					this.updateQuery(this.props.componentId, value);
+				}
+			}, 300)();
+		}
+		if (this.props.beforeValueChange) {
+			this.props.beforeValueChange(value)
+				.then(() => {
+					performUpdate();
+				})
+				.catch((e) => {
+					console.warn(`${this.props.componentId} - beforeValueChange rejected the promise with `, e);
+				});
 		} else {
+			performUpdate();
+		}
+	};
+
+	setDefaultValue = (value) => {
+		const performUpdate = () => {
+			if (this.props.onValueChange) {
+				this.props.onValueChange(value);
+			}
+			this.setState({
+				currentValue: value
+			});
+			if (this.props.autoSuggest) {
+				this.updateQuery(this.internalComponent, value);
+			}
 			this.updateQuery(this.props.componentId, value);
+		}
+		if (this.props.beforeValueChange) {
+			this.props.beforeValueChange(value)
+				.then(() => {
+					performUpdate();
+				})
+				.catch((e) => {
+					console.warn(`${this.props.componentId} - beforeValueChange rejected the promise with `, e);
+				});
+		} else {
+			performUpdate();
 		}
 	};
 
 	selectSuggestion = (value) => {
 		this.setState({
-			currentValue: value,
 			suggestions: []
 		});
-		this.updateQuery(this.props.componentId, value);
+		this.setDefaultValue(value);
 		this.toggleModal();
 	};
 
@@ -186,6 +222,15 @@ class DataSearch extends Component {
 		this.setState({
 			showModal: !this.state.showModal
 		})
+	};
+
+	updateQuery = (component, value) => {
+		const query = this.props.customQuery || this.defaultQuery;
+		let callback = null;
+		if (component === this.props.componentId && this.props.onQueryChange) {
+			callback = this.props.onQueryChange;
+		}
+		this.props.updateQuery(component, query(value), callback);
 	};
 
 	renderSuggestions() {


### PR DESCRIPTION
I think for React Components we should use prop-types instead of flow. It's making things complicated IMO. For ref - [flow coverage on DataController](https://github.com/divyanshu013/reactivebase-native/commit/8d0a895f3d302dd40a5cfb184ed0ca4d874ee54e) (still failing flow tests) :face_with_head_bandage: 

@metagrover can you give it a try expanding on the above commit and see if flow sounds good for the components too?